### PR TITLE
More reasonable error message when build-management.yml is not found

### DIFF
--- a/DockerBuildManagement/BuildManager.py
+++ b/DockerBuildManagement/BuildManager.py
@@ -44,8 +44,8 @@ def HandleManagement(arguments):
         TestSelections.HandleTestSelections(arguments)
         RunSelections.HandleRunSelections(arguments)
         PublishSelections.HandlePublishSelections(arguments)
-    except FileNotFoundError:
-        print("\033[1;31;49m[dbm] Could not find build-management.yml in current directory.")
+    except FileNotFoundError as fileNotFound:
+        print("\033[1;31;49m[dbm] Could not find " + fileNotFound.filename + " in current directory.")
         exit(-1)
     except Exception as error:
         print (error)

--- a/DockerBuildManagement/BuildManager.py
+++ b/DockerBuildManagement/BuildManager.py
@@ -32,17 +32,24 @@ def HandleManagement(arguments):
         print(GetInfoMsg())
         return
 
-    SwarmTools.LoadEnvironmentVariables(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
-    SwarmTools.HandleDumpYamlData(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+    try:
+        SwarmTools.LoadEnvironmentVariables(
+            arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        SwarmTools.HandleDumpYamlData(
+            arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
 
-    ChangelogSelections.HandleChangelogSelections(arguments)
-    SwarmSelections.HandleSwarmSelections(arguments)
-    BuildSelections.HandleBuildSelections(arguments)
-    TestSelections.HandleTestSelections(arguments)
-    RunSelections.HandleRunSelections(arguments)
-    PublishSelections.HandlePublishSelections(arguments)
+        ChangelogSelections.HandleChangelogSelections(arguments)
+        SwarmSelections.HandleSwarmSelections(arguments)
+        BuildSelections.HandleBuildSelections(arguments)
+        TestSelections.HandleTestSelections(arguments)
+        RunSelections.HandleRunSelections(arguments)
+        PublishSelections.HandlePublishSelections(arguments)
+    except FileNotFoundError:
+        print("\033[1;31;49m[dbm] Could not find build-management.yml in current directory.")
+        exit(-1)
+    except Exception as error:
+        print (error)
+        exit(-1)
 
 if __name__ == "__main__":
     arguments = sys.argv[1:]


### PR DESCRIPTION
Showing a simple error message instead of printing the entire stack frame when DockerBuildManagement can not find build-management.yml.