### PR TITLE
Support for multiple default build files

### DIFF
--- a/DockerBuildManagement/BuildManager.py
+++ b/DockerBuildManagement/BuildManager.py
@@ -44,8 +44,8 @@ def HandleManagement(arguments):
         TestSelections.HandleTestSelections(arguments)
         RunSelections.HandleRunSelections(arguments)
         PublishSelections.HandlePublishSelections(arguments)
-    except FileNotFoundError:
-        print("\033[1;31;49m[dbm] Could not find build-management.yml in current directory.")
+    except FileNotFoundError as fileNotFound:
+        print("\033[1;31;49m[dbm] Could not find " + fileNotFound.filename + " in current directory.")
         exit(-1)
     except Exception as error:
         print (error)

--- a/DockerBuildManagement/BuildManager.py
+++ b/DockerBuildManagement/BuildManager.py
@@ -32,17 +32,24 @@ def HandleManagement(arguments):
         print(GetInfoMsg())
         return
 
-    SwarmTools.LoadEnvironmentVariables(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
-    SwarmTools.HandleDumpYamlData(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+    try:
+        SwarmTools.LoadEnvironmentVariables(
+            arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        SwarmTools.HandleDumpYamlData(
+            arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
 
-    ChangelogSelections.HandleChangelogSelections(arguments)
-    SwarmSelections.HandleSwarmSelections(arguments)
-    BuildSelections.HandleBuildSelections(arguments)
-    TestSelections.HandleTestSelections(arguments)
-    RunSelections.HandleRunSelections(arguments)
-    PublishSelections.HandlePublishSelections(arguments)
+        ChangelogSelections.HandleChangelogSelections(arguments)
+        SwarmSelections.HandleSwarmSelections(arguments)
+        BuildSelections.HandleBuildSelections(arguments)
+        TestSelections.HandleTestSelections(arguments)
+        RunSelections.HandleRunSelections(arguments)
+        PublishSelections.HandlePublishSelections(arguments)
+    except FileNotFoundError:
+        print("\033[1;31;49m[dbm] Could not find build-management.yml in current directory.")
+        exit(-1)
+    except Exception as error:
+        print (error)
+        exit(-1)
 
 if __name__ == "__main__":
     arguments = sys.argv[1:]

--- a/DockerBuildManagement/BuildSelections.py
+++ b/DockerBuildManagement/BuildSelections.py
@@ -19,7 +19,7 @@ def GetInfoMsg():
 
 def GetBuildSelections(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES])
     buildProperty = SwarmTools.GetProperties(arguments, BUILD_KEY, GetInfoMsg(), yamlData)
     if BuildTools.SELECTIONS_KEY in buildProperty:
         return buildProperty[BuildTools.SELECTIONS_KEY]

--- a/DockerBuildManagement/BuildTools.py
+++ b/DockerBuildManagement/BuildTools.py
@@ -13,7 +13,7 @@ COPY_FROM_CONTAINER_TAG = 'copyFromContainer'
 COPY_CONTAINER_SRC_TAG = 'containerSrc'
 COPY_HOST_DEST_TAG = 'hostDest'
 
-DEFAULT_BUILD_MANAGEMENT_YAML_FILE = 'build-management.yml'
+DEFAULT_BUILD_MANAGEMENT_YAML_FILES = ['build-management.yml', 'build.management.yml']
 
 
 def GetInfoMsg():

--- a/DockerBuildManagement/ChangelogSelections.py
+++ b/DockerBuildManagement/ChangelogSelections.py
@@ -16,7 +16,7 @@ def GetInfoMsg():
 
 def GetChangelogSelection(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES)
     return SwarmTools.GetProperties(arguments, CHANGELOG_KEY, GetInfoMsg(), yamlData)
 
 

--- a/DockerBuildManagement/PublishSelections.py
+++ b/DockerBuildManagement/PublishSelections.py
@@ -18,7 +18,7 @@ def GetInfoMsg():
 
 def GetPublishSelections(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES)
     publishProperty = SwarmTools.GetProperties(arguments, PUBLISH_KEY, GetInfoMsg(), yamlData)
     if BuildTools.SELECTIONS_KEY in publishProperty:
         return publishProperty[BuildTools.SELECTIONS_KEY]

--- a/DockerBuildManagement/RunSelections.py
+++ b/DockerBuildManagement/RunSelections.py
@@ -19,7 +19,7 @@ def GetInfoMsg():
 
 def GetRunSelections(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES)
     runProperty = SwarmTools.GetProperties(arguments, RUN_KEY, GetInfoMsg(), yamlData)
     if BuildTools.SELECTIONS_KEY in runProperty:
         return runProperty[BuildTools.SELECTIONS_KEY]

--- a/DockerBuildManagement/SwarmSelections.py
+++ b/DockerBuildManagement/SwarmSelections.py
@@ -24,7 +24,7 @@ def GetInfoMsg():
 
 def GetSwarmSelections(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES)
     swarmProperty = SwarmTools.GetProperties(arguments, SWARM_KEY, GetInfoMsg(), yamlData)
     if BuildTools.SELECTIONS_KEY in swarmProperty:
         return swarmProperty[BuildTools.SELECTIONS_KEY]

--- a/DockerBuildManagement/TestSelections.py
+++ b/DockerBuildManagement/TestSelections.py
@@ -20,7 +20,7 @@ def GetInfoMsg():
 
 def GetTestSelections(arguments):
     yamlData = SwarmTools.LoadYamlDataFromFiles(
-        arguments, [BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILE])
+        arguments, BuildTools.DEFAULT_BUILD_MANAGEMENT_YAML_FILES)
     testProperty = SwarmTools.GetProperties(arguments, TEST_KEY, GetInfoMsg(), yamlData)
     if BuildTools.SELECTIONS_KEY in testProperty:
         return testProperty[BuildTools.SELECTIONS_KEY]


### PR DESCRIPTION
DockerBuildManagement can now support multiple default build files. So build files can e.g have naming conventions as"build.management.yml", "build-management.yml" etc.